### PR TITLE
[이남곤] GroupMapper, GroupDto 수정

### DIFF
--- a/src/main/java/com/enjoytrip/group/entity/Group.java
+++ b/src/main/java/com/enjoytrip/group/entity/Group.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "Groups")
 public class Group extends BaseEntity {
 
     @Id

--- a/src/main/java/com/enjoytrip/group/mapper/GroupMapper.java
+++ b/src/main/java/com/enjoytrip/group/mapper/GroupMapper.java
@@ -11,14 +11,16 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface GroupMapper {
 
+    @Mapping(source = "id", target = "groupId")
     GroupDto.Get groupToGetRequest(Group group);
 
     List<GroupDto.Get> groupListToGetRequest(List<Group> group);
 
-    @Mapping(target = "memberId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "groupMemberList", ignore = true)
     Group postRequestToGroup(GroupDto.Post postRequest);
 
-    @Mapping(target = "memberId", ignore = true)
-    @Mapping(target = "groupId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "groupMemberList", ignore = true)
     Group patchRequestToGroup(GroupDto.Patch patchRequest, @MappingTarget Group group);
 }


### PR DESCRIPTION
## 개요

- GroupMapper와 GroupDto를 수정하였습니다.

## 세부 내용

- Group의 groupMemberList 매핑을 ignore 시켰습니다.
- Group은 SQL의 예약어이므로 테이블 이름을 수정하였습니다.

## 공유

## 이슈

- 엔티티의 하위 속성에 List가 있는 경우, Mapper 처리 방식에 대해 좀 더 알아봐야 합니다.