### PR TITLE
[이남곤] Post 관련 자잘한 수정

### DIFF
--- a/src/main/java/com/enjoytrip/post/dto/PostDto.java
+++ b/src/main/java/com/enjoytrip/post/dto/PostDto.java
@@ -1,6 +1,7 @@
 package com.enjoytrip.post.dto;
 
 import com.enjoytrip.group.dto.GroupDto;
+import com.enjoytrip.member.dto.MemberDto;
 import com.enjoytrip.post.entity.PostScope;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,7 +35,7 @@ public class PostDto {
     @Getter
     public static class Patch {
 
-        private Long postId;
+        private Long id;
         private Long writerId;
         private Long groupId;
         private String title;

--- a/src/main/java/com/enjoytrip/post/mapper/PostMapper.java
+++ b/src/main/java/com/enjoytrip/post/mapper/PostMapper.java
@@ -11,15 +11,17 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
-@RequiredArgsConstructor
 public abstract class PostMapper {
 
-    private final MemberService memberService;
-    private final GroupService groupService;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private GroupService groupService;
 
     public abstract PostDto.Get postToGetRequest(Post post);
 

--- a/src/main/java/com/enjoytrip/post/service/PostService.java
+++ b/src/main/java/com/enjoytrip/post/service/PostService.java
@@ -38,7 +38,7 @@ public class PostService {
     }
 
     public Post updatePost(PostDto.Patch patchRequest) {
-        Post post = findById(patchRequest.getPostId());
+        Post post = findById(patchRequest.getId());
         postMapper.patchRequestToPost(patchRequest, post);
         return postRepository.save(post);
     }


### PR DESCRIPTION
## 개요

- Post 관련 자잘한 수정이 있었습니다.

## 세부 내용

- Mapper에서 `@Autowired`를 사용하도록 했습니다.
- PatchDto에서 `postId` 대신 `id`로 수정하고 그로 인한 Service 계층에서의 수정이 있었습니다.
- `MemberDto.Get`를 가져오기 위한 import 문이 추가 되었습니다.

## 공유

## 이슈
