### PR TITLE
[이남곤] RestTemplate 주입을 위한 Bean 객체 생성

### DIFF
--- a/src/main/generated/com/enjoytrip/like/mapper/LikeMapperImpl.java
+++ b/src/main/generated/com/enjoytrip/like/mapper/LikeMapperImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-05-24T09:45:00+0900",
+    date = "2023-05-24T09:49:11+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.7 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/java/com/enjoytrip/product/openapi/RestTemplateClient.java
+++ b/src/main/java/com/enjoytrip/product/openapi/RestTemplateClient.java
@@ -1,0 +1,13 @@
+package com.enjoytrip.product.openapi;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateClient {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## 개요

- RestTemplate 주입을 위한 Bean 객체 생성

## 세부 내용

- `openapi `폴더 내에 RestTemplate 빈 생성을 위한 `RestTemplateClient`를 만들었습니다.

## 공유

## 이슈
